### PR TITLE
Prevent options being lost when using multiple source files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -133,6 +133,18 @@ module.exports = function (grunt) {
                     'test/tmp/not-annotated-ngannotateoptions.js': ['test/fixtures/not-annotated.js'],
                 },
             },
+            multipleFileSources: {
+                options: {
+                    add: false,
+                    remove: true,
+                },
+                files: [{
+                    expand: true,
+                    cwd: 'test/fixtures',
+                    src: ['multiple-1.js', 'multiple-2.js'],
+                    dest: 'test/tmp',
+                }],
+            },
         },
 
         // Unit tests.

--- a/tasks/ng-annotate.js
+++ b/tasks/ng-annotate.js
@@ -22,37 +22,37 @@ module.exports = function (grunt) {
             // Merge task-specific and/or target-specific options with these defaults.
                 options = this.options();
 
+            if (!options.ngAnnotateOptions) {
+                options.ngAnnotateOptions = {};
+            }
+
+            if (options.add != null) {
+                options.ngAnnotateOptions.add = options.add;
+                delete options.add;
+            } else {
+                options.ngAnnotateOptions.add = true;
+            }
+
+            if (options.remove != null) {
+                options.ngAnnotateOptions.remove = options.remove;
+                delete options.remove;
+            } else {
+                options.ngAnnotateOptions.remove = false;
+            }
+
+            if (options.regexp != null) {
+                options.ngAnnotateOptions.regexp = options.regexp;
+                delete options.regexp;
+            }
+
+            if (options.singleQuotes != null) {
+                options.ngAnnotateOptions.single_quotes = options.singleQuotes;
+                delete options.singleQuotes;
+            }
+
             // Iterate over all specified file groups.
             this.files.forEach(function (mapping) {
                 var tmpFilePath = mapping.dest; // use the destination file as a temporary source one
-
-                if (!options.ngAnnotateOptions) {
-                    options.ngAnnotateOptions = {};
-                }
-
-                if (options.add != null) {
-                    options.ngAnnotateOptions.add = options.add;
-                    delete options.add;
-                } else {
-                    options.ngAnnotateOptions.add = true;
-                }
-
-                if (options.remove != null) {
-                    options.ngAnnotateOptions.remove = options.remove;
-                    delete options.remove;
-                } else {
-                    options.ngAnnotateOptions.remove = false;
-                }
-
-                if (options.regexp != null) {
-                    options.ngAnnotateOptions.regexp = options.regexp;
-                    delete options.regexp;
-                }
-
-                if (options.singleQuotes != null) {
-                    options.ngAnnotateOptions.single_quotes = options.singleQuotes;
-                    delete options.singleQuotes;
-                }
 
                 if (mapping.dest) {
                     // If destination file provided, concatenate all source files to a temporary one.

--- a/test/fixtures/multiple-1.js
+++ b/test/fixtures/multiple-1.js
@@ -1,0 +1,33 @@
+(function () {
+    "use strict";
+
+    angular.module("app", ["dep1", "dep2"])
+        .run(["$rootScope", "$timeout", function ($rootScope, $timeout) {
+            $timeout(function () {
+                $rootScope.a = 2;
+            });
+            $rootScope.b = 2;
+        }])
+        .service("appService", ["$rootScope", function ($rootScope) {
+            this.getA = function getA() {
+                return $rootScope.a;
+            };
+        }])
+        .run(["appService", _.noop]);
+
+    var matchedMod = angular.module("app2", []);
+    var nonMatchedMod = angular.module("app3", []);
+
+    matchedMod.service("appService", ["$rootScope", function ($rootScope) {
+        this.getA = function getA() {
+            return $rootScope.a;
+        };
+    }]);
+
+
+    nonMatchedMod.service("appService", ["$rootScope", function ($rootScope) {
+        this.getA = function getA() {
+            return $rootScope.a;
+        };
+    }]);
+})();

--- a/test/fixtures/multiple-2.js
+++ b/test/fixtures/multiple-2.js
@@ -1,0 +1,33 @@
+(function () {
+    "use strict";
+
+    angular.module("app", ["dep1", "dep2"])
+        .run(["$rootScope", "$timeout", function ($rootScope, $timeout) {
+            $timeout(function () {
+                $rootScope.a = 2;
+            });
+            $rootScope.b = 2;
+        }])
+        .service("appService", ["$rootScope", function ($rootScope) {
+            this.getA = function getA() {
+                return $rootScope.a;
+            };
+        }])
+        .run(["appService", _.noop]);
+
+    var matchedMod = angular.module("app2", []);
+    var nonMatchedMod = angular.module("app3", []);
+
+    matchedMod.service("appService", ["$rootScope", function ($rootScope) {
+        this.getA = function getA() {
+            return $rootScope.a;
+        };
+    }]);
+
+
+    nonMatchedMod.service("appService", ["$rootScope", function ($rootScope) {
+        this.getA = function getA() {
+            return $rootScope.a;
+        };
+    }]);
+})();

--- a/test/spec/api.js
+++ b/test/spec/api.js
@@ -59,4 +59,9 @@ describe('grunt-ng-annotate API', function () {
     it('should pass the `ngAnnotateOptions` object to ngAnnotate', function () {
         expect(readTmp('not-annotated-ngannotateoptions.js')).to.be(readFix('annotated-single.js'));
     });
+
+    it('should pass the correct options when using multiple input sources', function () {
+        expect(readTmp('multiple-1.js')).to.be(readFix('not-annotated.js'));
+        expect(readTmp('multiple-2.js')).to.be(readFix('not-annotated.js'));
+    });
 });


### PR DESCRIPTION
When using multiple source files, the options are passed correctly for the first file but are lost for subsequent files, resulting in the default options being used.
