### PR TITLE
docs: update the grunt message

### DIFF
--- a/tasks/ng-annotate.js
+++ b/tasks/ng-annotate.js
@@ -194,7 +194,7 @@ module.exports = function (grunt) {
                 if (filesNum < 1) {
                     grunt.log.ok('No files provided to the ngAnnotate task.');
                 } else {
-                    grunt.log.ok(filesNum + (filesNum === 1 ? ' file' : ' files') + ' successfully generated.');
+                    grunt.log.ok(filesNum + (filesNum === 1 ? ' file' : ' files') + ' successfully annotated.');
                 }
             }
             return validRun;


### PR DESCRIPTION
Updated the grunt log message to say:
`x files successfully annotated` instead of `created` since created can
be slightly misleading